### PR TITLE
Adding a validate function to allow advanced validations

### DIFF
--- a/lib/file-uploader.js
+++ b/lib/file-uploader.js
@@ -11,6 +11,7 @@
       completeTemplateOther: '<p>The file has been uploaded &#x2714;</p>',
       images: ['jpg', 'png', 'bmp', 'gif', 'jpeg'],
       allow: [],
+      validateFunction: null,
       processData: null,
       zIndex: 2,
       dropZone: 'this',
@@ -138,6 +139,9 @@
     },
 
     checkType: function(file) {
+      if(this.validateFunction) {
+        return this.validateFunction(file);
+      }
       return !this.allow.length || $.inArray(this.getExtension(file), this.allow) !== -1;
     },
 

--- a/lib/file-uploader.js
+++ b/lib/file-uploader.js
@@ -140,7 +140,7 @@
 
     checkType: function(file) {
       if(this.validateFunction) {
-        return this.validateFunction(file);
+        return this.validateFunction.call(this, file);
       }
       return !this.allow.length || $.inArray(this.getExtension(file), this.allow) !== -1;
     },


### PR DESCRIPTION
This could allow for more advanced validations, ie using the same upload instance for both image and document types with separate validations.